### PR TITLE
refactor(storage): extract favorites storage into lib service

### DIFF
--- a/.github/copilot_pr_body.md
+++ b/.github/copilot_pr_body.md
@@ -21,4 +21,4 @@ Extract inline favorites storage from App into a reusable storage service. Adds 
 - [x] Backwards compatible change
 
 ### Demo
-![Favoriting stations demo](docs/favouriting_stations.gif)
+![Favoriting stations demo](/docs/favouriting_stations.gif)

--- a/.github/copilot_pr_body.md
+++ b/.github/copilot_pr_body.md
@@ -1,0 +1,24 @@
+## Summary
+
+Extract inline favorites storage from App into a reusable storage service. Adds a Set-based API and supports legacy key migration.
+
+## Changes
+- Add `src/lib/storage.ts` Set-based API: `getFavoriteIds` / `setFavoriteIds`
+- Keep back-compat array API: `getFavorites` / `setFavorites`
+- Legacy key support (reads `radio-favorites`, writes `rr_favorites_v1`, clears legacy on save)
+- Refactor `src/App.tsx` to use the storage service
+- Update README to reflect services layout
+
+## How to test
+- Start dev server and load app
+- Favorite/unfavorite stations; refresh to verify persistence
+- If `localStorage['radio-favorites']` exists from older runs, confirm favorites load and re-save under `rr_favorites_v1`
+- Run lint/typecheck/build locally to verify green
+
+## Checklist
+- [x] Tests/CI pass locally (lint, typecheck, build)
+- [x] Updated docs/README if needed
+- [x] Backwards compatible change
+
+### Demo
+![Favoriting stations demo](docs/favouriting_stations.gif)

--- a/.github/copilot_pr_body.md
+++ b/.github/copilot_pr_body.md
@@ -21,4 +21,4 @@ Extract inline favorites storage from App into a reusable storage service. Adds 
 - [x] Backwards compatible change
 
 ### Demo
-![Favoriting stations demo](/docs/favouriting_stations.gif)
+![Favoriting stations demo](https://github.com/ThatChocolateGuy/react-radio/blob/6b188a578cab85c17b88b04b6c9ec0b100b0445f/docs/favouriting_stations.gif?raw=true)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ While this app doesn't have a traditional backend microservice architecture, its
     - Concept: One module to own network calls, error handling, caching, and any station-related transformations. Call `fetchStations()` from your components (e.g., inside `useEffect`) instead of using a global `allStations` constant so the rest of the app doesn't need to change if the backend or auth changes.
 
 2. The "Browser Storage Service"
-    - File: `src/App.tsx`
+    - File: `src/lib/storage.ts`
     - Code Block: The `storage` object with `getFavoriteIds` and `setFavoriteIds` methods.
     - Concept: This acts as our database layer. It abstracts away the implementation details of how we're storing data (in this case, `localStorage`). If we decided to store favorites in a different way (like `sessionStorage` or an online database like Firebase), we would only need to update the methods inside this `storage` object. The rest of the application wouldn't need to change.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,14 @@ While this app doesn't have a traditional backend microservice architecture, its
 
 2. The "Browser Storage Service"
     - File: `src/lib/storage.ts`
-    - Code Block: The `storage` object with `getFavoriteIds` and `setFavoriteIds` methods.
-    - Concept: This acts as our database layer. It abstracts away the implementation details of how we're storing data (in this case, `localStorage`). If we decided to store favorites in a different way (like `sessionStorage` or an online database like Firebase), we would only need to update the methods inside this `storage` object. The rest of the application wouldn't need to change.
+    - Exports:
+        - `getFavoriteIds(): Set<string>` — returns the favorited station IDs as a Set
+        - `setFavoriteIds(ids: Set<string>): void` — persists the Set of IDs
+        - `getFavorites(): string[]` — back-compat helper that returns an array
+        - `setFavorites(list: string[]): void` — back-compat helper that accepts an array
+    - Notes:
+        - Stores under the key `rr_favorites_v1`; reads legacy `radio-favorites` for migration and clears it on save.
+    - Concept: This module is the data layer for favorites. If we switch storage (e.g., `sessionStorage` or a remote DB), we update only this file; the rest of the app remains unchanged.
 
 3. The "Recommendation Service"
     - File: `src/App.tsx`

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ The primary goal of this project is to provide a clear and easy-to-understand co
 While this app doesn't have a traditional backend microservice architecture, its code is structured to mimic that separation of concerns. This is a great way to organize frontend applications.
 
 1. The "Station Data Service"
-    - File: `src/App.tsx`
-    - Code Block: The `allStations` constant array.
-    - Concept: In a real-world application, this data would be fetched from a dedicated "Stations API". By keeping it as a simple, separate constant, we isolate our data source. If we wanted to switch to a real API, we would only need to change this one part of the code (e.g., replace the constant with a `useEffect` hook that calls `fetch`).
+    - File: `src/services/stationService.ts`
+    - Exports (examples):
+        - `export async function fetchStations(): Promise<Station[]>` — fetches the stations API, throws on HTTP errors, returns parsed JSON.
+        - `export function getCachedStations(): Station[]` — returns an in-memory cache or the fallback `allStations`.
+        - `export async function getStationById(id: string): Promise<Station | undefined>` — finds a single station (from cache or by fetching).
+        - `export const allStations: Station[]` — a small local fallback dataset used when network calls fail or for quick local dev.
+    - Concept: One module to own network calls, error handling, caching, and any station-related transformations. Call `fetchStations()` from your components (e.g., inside `useEffect`) instead of using a global `allStations` constant so the rest of the app doesn't need to change if the backend or auth changes.
 
 2. The "Browser Storage Service"
     - File: `src/App.tsx`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,9 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { fetchStations } from './services/stationService';
 import type { ServiceStation } from './types';
+import { getFavoriteIds as storageGetFavoriteIds, setFavoriteIds as storageSetFavoriteIds } from './lib/storage';
 
 type Station = ServiceStation;
-
-//===========//
-// --- 3. "BROWSER STORAGE MICROSERVICE" --- //
-// This section simulates a service that handles data persistence. Instead of a
-// database, we use the browser's `localStorage`. These helper functions
-// provide a clean way to get and set favorite station IDs.
-//===========//
-const storage = {
-  getFavoriteIds: (): Set<string> => {
-    try {
-      const item = localStorage.getItem('radio-favorites');
-      return item ? new Set(JSON.parse(item)) : new Set();
-    } catch (error) {
-      console.error("Error reading favorites from localStorage", error);
-      return new Set();
-    }
-  },
-  setFavoriteIds: (ids: Set<string>) => {
-    try {
-      localStorage.setItem('radio-favorites', JSON.stringify(Array.from(ids)));
-    } catch (error) {
-      console.error("Error saving favorites to localStorage", error);
-    }
-  },
-};
 
 //===========//
 // --- 4. UI ICON COMPONENTS --- //
@@ -50,15 +26,13 @@ const StarIcon = ({ className, isFilled }: { className?: string; isFilled: boole
 // storage, state, and UI.
 //===========//
 export default function App() {
-  // Load stations from the service
+  // --- STATE MANAGEMENT --- //
   const [allStations, setAllStations] = useState<Station[]>([]);
   const [loadingStations, setLoadingStations] = useState(true);
-  // --- STATE MANAGEMENT --- //
-  // `useState` is a React Hook to hold component state.
   const [currentStation, setCurrentStation] = useState<Station | null>(null);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   // We initialize favorites by reading from our "storage service".
-  const [favoriteIds, setFavoriteIds] = useState<Set<string>>(storage.getFavoriteIds());
+  const [favoriteIds, setFavoriteIds] = useState<Set<string>>(storageGetFavoriteIds());
 
   // `useRef` is used to get a direct reference to an HTML element, in this
   // case, the <audio> tag. This lets us control it programmatically.
@@ -135,7 +109,7 @@ export default function App() {
     }
     setFavoriteIds(newFavoriteIds);
     // Persist the change to our "storage service".
-    storage.setFavoriteIds(newFavoriteIds);
+    storageSetFavoriteIds(newFavoriteIds);
   };
   
   // --- RENDER --- //

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,18 +1,52 @@
 const FAVORITES_KEY = "rr_favorites_v1";
+const LEGACY_KEYS = ["radio-favorites"]; // older key used in early versions
 
-export function getFavorites(): string[] {
+// New preferred API: work with Set<string>
+export function getFavoriteIds(): Set<string> {
+  // Try the current key first
   try {
     const raw = localStorage.getItem(FAVORITES_KEY);
-    return raw ? JSON.parse(raw) : [];
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr)) return new Set(arr.map(String));
+    }
   } catch {
-    return [];
+    // ignore and try legacy keys below
   }
+
+  // Fall back to legacy keys if present
+  for (const key of LEGACY_KEYS) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        const arr = JSON.parse(raw);
+        if (Array.isArray(arr)) return new Set(arr.map(String));
+      }
+    } catch {
+      // continue checking others
+    }
+  }
+
+  return new Set<string>();
 }
 
-export function setFavorites(list: string[]) {
+export function setFavoriteIds(ids: Set<string>) {
   try {
-    localStorage.setItem(FAVORITES_KEY, JSON.stringify(list));
+    localStorage.setItem(FAVORITES_KEY, JSON.stringify(Array.from(ids)));
+    // Optionally clear legacy keys to avoid confusion
+    for (const key of LEGACY_KEYS) {
+      try { localStorage.removeItem(key); } catch { /* noop */ }
+    }
   } catch {
     // ignore storage errors
   }
+}
+
+// Back-compat API kept for existing imports
+export function getFavorites(): string[] {
+  return Array.from(getFavoriteIds());
+}
+
+export function setFavorites(list: string[]) {
+  setFavoriteIds(new Set(list));
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -35,7 +35,7 @@ export function setFavoriteIds(ids: Set<string>) {
     localStorage.setItem(FAVORITES_KEY, JSON.stringify(Array.from(ids)));
     // Optionally clear legacy keys to avoid confusion
     for (const key of LEGACY_KEYS) {
-      try { localStorage.removeItem(key); } catch { /* noop */ }
+      try { localStorage.removeItem(key); } catch { /* ignore removal errors */ }
     }
   } catch {
     // ignore storage errors


### PR DESCRIPTION
## Summary

Extract inline favorites storage from App into a reusable storage service. Adds a Set-based API and supports legacy key migration.

## Changes
- Add `src/lib/storage.ts` Set-based API: `getFavoriteIds` / `setFavoriteIds`
- Keep back-compat array API: `getFavorites` / `setFavorites`
- Legacy key support (reads `radio-favorites`, writes `rr_favorites_v1`, clears legacy on save)
- Refactor `src/App.tsx` to use the storage service
- Update README to reflect services layout

## How to test
- Start dev server and load app
- Favorite/unfavorite stations; refresh to verify persistence
- If `localStorage['radio-favorites']` exists from older runs, confirm favorites load and re-save under `rr_favorites_v1`
- Run lint/typecheck/build locally to verify green

## Checklist
- [x] Tests/CI pass locally (lint, typecheck, build)
- [x] Updated docs/README if needed
- [x] Backwards compatible change

### Demo
![Favoriting stations demo](https://github.com/ThatChocolateGuy/react-radio/blob/6b188a578cab85c17b88b04b6c9ec0b100b0445f/docs/favouriting_stations.gif?raw=true)